### PR TITLE
Réduction des requêtes Algolia: suppression "Tous", gate requêtes vides, teaser différé, proxy en dev

### DIFF
--- a/src/components/search/algolia/SearchFilters.tsx
+++ b/src/components/search/algolia/SearchFilters.tsx
@@ -104,16 +104,6 @@ const OriginFilter: React.FC = () => {
     <div className="flex flex-col gap-2">
       <Button
         size="sm"
-        variant={origin === 'all' ? 'default' : 'outline'}
-        onClick={() => {
-          debug('click all');
-          setOrigin('all');
-        }}
-      >
-        Tous
-      </Button>
-      <Button
-        size="sm"
         variant={origin === 'public' ? 'default' : 'outline'}
         onClick={() => {
           debug('click public');


### PR DESCRIPTION
- Supprime l’option "Tous" dans `SearchFilters` (search et favoris partagent le composant)
- Origine par défaut `public` dans `SearchProvider`
- Garde‑fou: ne pas requêter Algolia si query vide et aucun filtre actif
- Teaser chargé en différé après 400ms d’inactivité (réduit les appels perçus)
- En dev/prod, passage par le proxy pour regrouper les multi‑queries en un seul HTTP

Impact:
- 0 appel au load
- 1 appel en base privée, 1–2 appels en base publique (selon teaser autorisé)

Merci pour la review.
