### PR TITLE
feat(teaser+RLS): MV publique floutée, RLS ef_all, refresh auto + hooks rebuild

### DIFF
--- a/supabase/functions/ef-teaser-public/index.ts
+++ b/supabase/functions/ef-teaser-public/index.ts
@@ -1,0 +1,49 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+}
+
+function json(status: number, body: any) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+  })
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  if (req.method !== 'GET') return json(405, { error: 'Method not allowed' })
+
+  try {
+    const url = new URL(req.url)
+    const q = url.searchParams.get('q') || ''
+    const source = url.searchParams.get('source') || undefined
+    const limit = Math.min(Number(url.searchParams.get('limit') || 20), 100)
+
+    const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
+    const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!
+    const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+    let query = supabase
+      .from('emission_factors_teaser_public_fr')
+      .select('*')
+      .limit(limit)
+
+    if (source) query = query.eq('Source', source)
+    if (q) {
+      // Filtre simple côté DB: il est recommandé d'utiliser Algolia via l'edge proxy pour le search plein-texte
+      query = query.ilike('Nom', `%${q}%`)
+    }
+
+    const { data, error } = await query
+    if (error) return json(500, { error: error.message })
+    return json(200, { items: data })
+  } catch (e) {
+    return json(500, { error: String(e) })
+  }
+})
+
+

--- a/supabase/migrations/20250820123000_secure_ef_all_rls.sql
+++ b/supabase/migrations/20250820123000_secure_ef_all_rls.sql
@@ -1,0 +1,51 @@
+-- Sécurisation de public.emission_factors_all_search
+-- Objectif: empêcher toute fuite de données business (workspace_id, premium)
+
+-- 1) Activer RLS et retirer tout accès public/anon
+ALTER TABLE public.emission_factors_all_search ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.emission_factors_all_search FROM PUBLIC;
+REVOKE ALL ON TABLE public.emission_factors_all_search FROM anon;
+
+-- 2) Nettoyage d'anciennes policies trop permissives (idempotent)
+DROP POLICY IF EXISTS "Public access to emission factors search" ON public.emission_factors_all_search;
+DROP POLICY IF EXISTS "Authenticated users can view emission factors search" ON public.emission_factors_all_search;
+DROP POLICY IF EXISTS "ef_all_select_authenticated" ON public.emission_factors_all_search;
+DROP POLICY IF EXISTS "ef_all_service_full" ON public.emission_factors_all_search;
+
+-- 3) Policies sûres
+-- Accès lecture pour les utilisateurs authentifiés, limité par appartenance workspace
+CREATE POLICY "ef_all_select_authenticated"
+ON public.emission_factors_all_search
+FOR SELECT
+TO authenticated
+USING (
+  -- Données d’un workspace dont je suis membre
+  (workspace_id IN (
+     SELECT w.id
+     FROM public.workspaces w
+     LEFT JOIN public.user_roles ur ON ur.workspace_id = w.id
+     WHERE w.owner_id = (select auth.uid()) OR ur.user_id = (select auth.uid())
+  ))
+  OR
+  -- Données globales standard accessibles à tous les authentifiés
+  (workspace_id IS NULL AND access_level = 'standard')
+  OR
+  -- Données premium globales accessibles uniquement si mon workspace est attribué
+  (
+    assigned_workspace_ids && (
+      SELECT coalesce(array_agg(ur.workspace_id), '{}'::uuid[])
+      FROM public.user_roles ur
+      WHERE ur.user_id = (select auth.uid())
+    )
+  )
+);
+
+-- Accès intégral côté serveur (Edge Functions) via service_role
+CREATE POLICY "ef_all_service_full"
+ON public.emission_factors_all_search
+AS PERMISSIVE
+FOR SELECT
+TO service_role
+USING (true);
+
+

--- a/supabase/migrations/20250820124500_public_teaser_view.sql
+++ b/supabase/migrations/20250820124500_public_teaser_view.sql
@@ -1,0 +1,50 @@
+-- Vue publique "teaser" sûre basée sur emission_factors_all_search
+-- Expose uniquement des champs non sensibles et floute systématiquement le premium
+
+DROP VIEW IF EXISTS public.emission_factors_teaser_public_fr;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.emission_factors_teaser_public_fr AS
+SELECT
+  ef.object_id,
+  'fr'::text AS language,
+  ef.scope,
+  ef.access_level,
+  ef."Source",
+  ef."Date",
+  ef."Nom_fr"           AS "Nom",
+  ef."Secteur_fr"       AS "Secteur",
+  ef."Sous-secteur_fr"  AS "Sous-secteur",
+  ef."Localisation_fr"  AS "Localisation",
+  ef."Périmètre_fr"     AS "Périmètre",
+  CASE WHEN ef.access_level = 'premium' THEN NULL ELSE ef."Description_fr" END AS "Description",
+  CASE WHEN ef.access_level = 'premium' THEN NULL ELSE ef."FE" END AS "FE",
+  CASE WHEN ef.access_level = 'premium' THEN NULL ELSE ef."Unite_fr" END AS "Unité donnée d'activité",
+  CASE WHEN ef.access_level = 'premium' THEN NULL ELSE ef."Commentaires_fr" END AS "Commentaires",
+  (ef.access_level = 'premium') AS is_blurred
+FROM public.emission_factors_all_search ef
+WHERE ef.scope = 'public';
+
+-- Droits: lecture publique (teaser) + lecture pour authenticated
+REVOKE ALL ON TABLE public.emission_factors_teaser_public_fr FROM PUBLIC;
+GRANT SELECT ON TABLE public.emission_factors_teaser_public_fr TO anon;
+GRANT SELECT ON TABLE public.emission_factors_teaser_public_fr TO authenticated;
+
+CREATE INDEX IF NOT EXISTS idx_teaser_fr_source ON public.emission_factors_teaser_public_fr ("Source");
+CREATE INDEX IF NOT EXISTS idx_teaser_fr_nom ON public.emission_factors_teaser_public_fr ("Nom");
+
+COMMENT ON MATERIALIZED VIEW public.emission_factors_teaser_public_fr IS 'Vue matérialisée publique teaser: premium flouté, standard visible';
+
+CREATE OR REPLACE FUNCTION public.refresh_emission_factors_teaser_public_fr()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM set_config('statement_timeout', '0', true);
+  REFRESH MATERIALIZED VIEW public.emission_factors_teaser_public_fr;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.refresh_emission_factors_teaser_public_fr() TO authenticated;
+

--- a/supabase/migrations/20250820130000_refresh_teaser_on_rebuild.sql
+++ b/supabase/migrations/20250820130000_refresh_teaser_on_rebuild.sql
@@ -1,0 +1,44 @@
+-- Rafraîchissement automatique de la MV teaser lors des rebuilds de ef_all
+
+-- 1) Index unique pour permettre REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teaser_fr_unique_object
+ON public.emission_factors_teaser_public_fr(object_id);
+
+-- 2) Mettre à jour la fonction de refresh pour tenter CONCURRENTLY avec repli
+CREATE OR REPLACE FUNCTION public.refresh_emission_factors_teaser_public_fr()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM set_config('statement_timeout', '0', true);
+  BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY public.emission_factors_teaser_public_fr;
+  EXCEPTION WHEN others THEN
+    -- Repli si l'index unique n'est pas disponible ou en cas de verrouillage
+    REFRESH MATERIALIZED VIEW public.emission_factors_teaser_public_fr;
+  END;
+END;
+$$;
+
+-- 3) Déclencheur: après insertion massive (rebuild), rafraîchir la MV une fois
+CREATE OR REPLACE FUNCTION public.refresh_teaser_after_ef_all_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.refresh_emission_factors_teaser_public_fr();
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ef_all_after_insert_refresh_teaser ON public.emission_factors_all_search;
+CREATE TRIGGER ef_all_after_insert_refresh_teaser
+AFTER INSERT ON public.emission_factors_all_search
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.refresh_teaser_after_ef_all_insert();
+
+

--- a/supabase/migrations/20250820130500_refresh_teaser_in_rebuild_functions.sql
+++ b/supabase/migrations/20250820130500_refresh_teaser_in_rebuild_functions.sql
@@ -1,0 +1,101 @@
+-- Surcharger les fonctions de rebuild pour rafraîchir la MV teaser
+
+CREATE OR REPLACE FUNCTION public.rebuild_emission_factors_all_search()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM set_config('statement_timeout', '0', true);
+
+  TRUNCATE TABLE public.emission_factors_all_search;
+
+  INSERT INTO public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "FE","Date","Incertitude","Source"
+  )
+  SELECT
+    ef.id as object_id,
+    ef.id as record_id,
+    CASE WHEN ef.workspace_id IS NULL THEN 'public' ELSE 'private' END as scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      SELECT array_agg(ws.workspace_id)
+      FROM public.fe_source_workspace_assignments ws
+      WHERE ws.source_name = ef."Source"
+    ) as assigned_workspace_ids,
+    ARRAY['fr']::text[] as languages,
+    ef."Nom" as "Nom_fr",
+    ef."Description" as "Description_fr",
+    ef."Commentaires" as "Commentaires_fr",
+    ef."Secteur" as "Secteur_fr",
+    ef."Sous-secteur" as "Sous-secteur_fr",
+    ef."Périmètre" as "Périmètre_fr",
+    ef."Localisation" as "Localisation_fr",
+    ef."Unité donnée d'activité" as "Unite_fr",
+    nullif(ef."FE", '')::numeric as "FE",
+    CASE WHEN ef."Date" ~ '^\d+$' THEN ef."Date"::integer ELSE NULL END as "Date",
+    ef."Incertitude" as "Incertitude",
+    ef."Source" as "Source"
+  FROM public.emission_factors ef
+  JOIN public.fe_sources fs ON fs.source_name = ef."Source"
+  WHERE ef.is_latest = true;
+
+  RAISE NOTICE 'ef_all projection rebuilt: % rows', (SELECT count(*) FROM public.emission_factors_all_search);
+
+  -- Rafraîchir la MV teaser en fin de rebuild
+  PERFORM public.refresh_emission_factors_teaser_public_fr();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_projection_for_source(p_source text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  DELETE FROM public.emission_factors_all_search WHERE "Source" = p_source;
+
+  INSERT INTO public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "FE","Date","Incertitude","Source"
+  )
+  SELECT
+    ef.id as object_id,
+    ef.id as record_id,
+    CASE WHEN ef.workspace_id IS NULL THEN 'public' ELSE 'private' END as scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      SELECT array_agg(ws.workspace_id)
+      FROM public.fe_source_workspace_assignments ws
+      WHERE ws.source_name = ef."Source"
+    ) as assigned_workspace_ids,
+    ARRAY['fr']::text[] as languages,
+    ef."Nom" as "Nom_fr",
+    ef."Description" as "Description_fr",
+    ef."Commentaires" as "Commentaires_fr",
+    ef."Secteur" as "Secteur_fr",
+    ef."Sous-secteur" as "Sous-secteur_fr",
+    ef."Périmètre" as "Périmètre_fr",
+    ef."Localisation" as "Localisation_fr",
+    ef."Unité donnée d'activité" as "Unite_fr",
+    nullif(ef."FE", '')::numeric as "FE",
+    CASE WHEN ef."Date" ~ '^\d+$' THEN ef."Date"::integer ELSE NULL END as "Date",
+    ef."Incertitude" as "Incertitude",
+    ef."Source" as "Source"
+  FROM public.emission_factors ef
+  JOIN public.fe_sources fs ON fs.source_name = ef."Source"
+  WHERE ef.is_latest = true AND ef."Source" = p_source;
+
+  RAISE NOTICE 'ef_all refreshed for source: %', p_source;
+
+  -- Rafraîchir la MV teaser après refresh ciblé
+  PERFORM public.refresh_emission_factors_teaser_public_fr();
+END;
+$$;


### PR DESCRIPTION
Contenu:\n- RLS stricte sur public.emission_factors_all_search (blocage anon, filtres workspace/attributions).\n- MV publique materialisée emission_factors_teaser_public_fr (+ fonction de refresh).\n- Trigger refresh après inserts de ef_all + appels explicites dans rebuild/refresh.\n- Edge Function GET ef-teaser-public.\n\nNotes:\n- DB appliquée et fonction Edge déployée; cette PR aligne le repo main.\n- Pas de changement de schéma cassant côté client (teaser publique uniquement).