### PR TITLE
feat: batch admin import + optimized reindex (single waitTask, configurable columns/page size)

### DIFF
--- a/src/components/admin/AdminImportsPanel.tsx
+++ b/src/components/admin/AdminImportsPanel.tsx
@@ -14,7 +14,7 @@ interface ImportJob {
   status: 'queued' | 'processing' | 'completed' | 'failed' | 'analyzing' | 'analyzed' | 'rebuilding' | string | null;
   processed: number | null;
   failed: number | null;
-  created_at: string;
+  started_at: string;
 }
 
 type AccessLevel = 'standard' | 'premium';
@@ -224,16 +224,16 @@ export const AdminImportsPanel: React.FC = () => {
       setLoadingJobs(true);
       const { data, error } = await supabase
         .from('data_imports')
-        .select('id,status,records_processed,records_failed,created_at,completed_at')
-        .order('created_at', { ascending: false })
+        .select('id,status,processed,failed,started_at,finished_at')
+        .order('started_at', { ascending: false })
         .limit(50);
       if (error) throw error;
       const mapped: ImportJob[] = (data || []).map((d: any) => ({
         id: d.id,
         status: d.status,
-        processed: d.records_processed ?? null,
-        failed: d.records_failed ?? null,
-        created_at: d.created_at,
+        processed: d.processed ?? null,
+        failed: d.failed ?? null,
+        started_at: d.started_at,
       }));
       setJobs(mapped);
     } catch (e) {
@@ -421,7 +421,7 @@ export const AdminImportsPanel: React.FC = () => {
                   <tr><td className="p-2" colSpan={4}>Aucun import pour le moment.</td></tr>
                 ) : jobs.map((j) => (
                   <tr key={j.id} className="border-t">
-                    <td className="p-2 whitespace-nowrap">{new Date(j.created_at).toLocaleString()}</td>
+                    <td className="p-2 whitespace-nowrap">{new Date(j.started_at).toLocaleString()}</td>
                     <td className="p-2">{j.status ?? '-'}</td>
                     <td className="p-2 text-right">{j.processed ?? '-'}</td>
                     <td className="p-2 text-right">{j.failed ?? '-'}</td>

--- a/src/components/workspace/WorkspaceUsersManager.tsx
+++ b/src/components/workspace/WorkspaceUsersManager.tsx
@@ -301,7 +301,7 @@ export const WorkspaceUsersManager = () => {
           </Alert>
         ) : (
           <div className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm font-medium text-muted-foreground border-b pb-2">
+            <div className="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_auto_1fr_auto] gap-4 text-sm font-medium text-muted-foreground border-b pb-2 text-left">
               <div>Utilisateur</div>
               <div>Rôle</div>
               <div>Ajouté le</div>
@@ -309,26 +309,26 @@ export const WorkspaceUsersManager = () => {
             </div>
             
             {users.map((user) => (
-              <div key={user.user_id} className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center p-4 border rounded-lg">
-                <div className="flex items-center gap-3">
+              <div key={user.user_id} className="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_auto_1fr_auto] gap-4 items-center p-4 border rounded-lg">
+                <div className="flex min-w-0 items-center gap-3">
                   <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
                     <span className="text-sm font-medium">
                       {user.first_name?.[0] || user.email[0].toUpperCase()}
                     </span>
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <div className="font-medium">
                       {user.first_name && user.last_name ? 
                         `${user.first_name} ${user.last_name}` : 
                         'Utilisateur'
                       }
                     </div>
-                    <div className="text-sm text-muted-foreground">{user.email}</div>
+                    <div className="text-sm text-muted-foreground truncate">{user.email}</div>
                   </div>
                 </div>
                 
-                <div className="flex items-center gap-2">
-                  <Badge variant={getRoleBadgeVariant(user.user_roles[0]?.role)} className="flex items-center gap-1">
+                <div className="flex items-center gap-2 justify-start">
+                  <Badge variant={getRoleBadgeVariant(user.user_roles[0]?.role)} className="flex items-center gap-1 whitespace-nowrap">
                     {React.createElement(getRoleIcon(user.user_roles[0]?.role), { className: "h-3 w-3" })}
                     {user.user_roles[0]?.role === 'admin' ? 'Administrateur' : 'Gestionnaire'}
                   </Badge>

--- a/supabase/functions/import-csv-user/index.ts
+++ b/supabase/functions/import-csv-user/index.ts
@@ -107,7 +107,14 @@ Deno.serve(async (req) => {
 
     const importInsert = await supabase
       .from('data_imports')
-      .insert({ imported_by: user.id, file_name: filePath.split('/').pop(), status: 'processing', started_at: new Date().toISOString() })
+      .insert({
+        user_id: user.id,
+        storage_path: filePath,
+        file_name: filePath.split('/').pop(),
+        language,
+        status: 'processing',
+        started_at: new Date().toISOString()
+      })
       .select('*')
       .single()
     if (importInsert.error) return json(500, { error: 'Failed to create import record' })


### PR DESCRIPTION
Cette PR apporte des optimisations majeures sur l’ingestion et la reindexation Algolia.

Changements principaux:

- import-csv (admin)
  - Ingestion en batch (~1000 lignes) au lieu d’insertions unitaire
  - Fermeture SCD2 par lots (UPDATE IN (...) + INSERT bulk)
  - Alignement du schéma data_imports (user_id, storage_path, processed/failed/started_at)

- reindex-ef-all-atomic
  - Attente d’un seul taskID Algolia (dernier) au lieu d’un wait après chaque chunk
  - Colonnes projetées configurables via REINDEX_SELECT_COLUMNS (réduction payload)
  - REINDEX_PAGE_SIZE configurable

- Admin UI
  - Historique `data_imports` lit processed/failed/started_at

Notes d’exploitation:
- Configurer REINDEX_SELECT_COLUMNS avec les attributs Algolia requis (ex: `object_id,Nom_fr,Nom_en,FE,Unite_fr,Unite_en,Source,scope,languages,assigned_workspace_ids,workspace_id`).
- Ajuster REINDEX_PAGE_SIZE si besoin (ex: 3000) selon mémoire/latence.

Impact:
- Moins d’allers-retours réseau et meilleure tenue sur gros CSV (~50Mo)
- Coûts Algolia/Supabase réduits (moins de waitTasks et payload allégé)
