### PR TITLE
Supprimer le bloc Performance du Cache non fonctionnel du dashboard Algolia

### DIFF
--- a/src/components/admin/AlgoliaPerformanceDashboard.tsx
+++ b/src/components/admin/AlgoliaPerformanceDashboard.tsx
@@ -230,30 +230,7 @@ export const AlgoliaPerformanceDashboard: React.FC = () => {
         </TabsList>
 
         <TabsContent value="overview" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Cache Performance */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Performance du Cache</CardTitle>
-                <CardDescription>Efficacité du système de cache</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="flex justify-between items-center">
-                    <span>Taux de hit</span>
-                    <span className="font-bold">{metrics.cacheHitRate.toFixed(1)}%</span>
-                  </div>
-                  <Progress value={metrics.cacheHitRate} />
-                  
-                  <div className="flex justify-between items-center">
-                    <span>Déduplication</span>
-                    <span className="font-bold">{metrics.deduplicationRate.toFixed(1)}%</span>
-                  </div>
-                  <Progress value={metrics.deduplicationRate} />
-                </div>
-              </CardContent>
-            </Card>
-
+          <div className="grid grid-cols-1 gap-4">
             {/* Top Search Terms */}
             <Card>
               <CardHeader>


### PR DESCRIPTION
## Description

Ce PR supprime le bloc "Performance du Cache" du dashboard de performance Algolia dans l'interface admin, car il n'était pas fonctionnel et n'apportait pas de valeur.

## Changements

- ✅ Suppression du bloc "Performance du Cache" avec ses métriques de taux de hit et déduplication
- ✅ Ajustement de la grille de la section "Vue d'ensemble" de 2 colonnes à 1 colonne
- ✅ Conservation du bloc "Termes de recherche populaires" qui reste fonctionnel

## Impact

- Interface admin plus propre et focalisée sur les métriques utiles
- Suppression de code non fonctionnel
- Aucun impact sur les fonctionnalités existantes

## Test

- [x] Vérification que le dashboard se charge correctement
- [x] Confirmation que la mise en page est cohérente
- [x] Linter OK