### PR TITLE
feat: ajouter vercel.json pour résoudre le routage des pages SPA

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 🚀 Résolution du problème de routage sur Vercel

### Problème
La page `/admin` n'était pas accessible sur Vercel (erreur 404) car l'application React Router n'avait pas de configuration de routage appropriée.

### Solution
Ajout d'un fichier `vercel.json` avec la configuration de rewrites pour rediriger toutes les routes vers `index.html`, permettant à React Router de gérer le routage côté client.

### Changements
- ✅ Ajout de `vercel.json` avec configuration de rewrites
- ✅ Toutes les routes (y compris `/admin`) seront maintenant accessibles
- ✅ Aucun impact sur la logique métier existante

### Test
Après déploiement, la route `/admin` devrait être accessible sur `https://datacarb.vercel.app/admin`