### PR TITLE
chore(db): fix Supabase advisors lints — set security_invoker on view and pin search_path on functions

### DIFF
--- a/supabase/migrations/20250827121000_fix_security_invoker_and_search_path.sql
+++ b/supabase/migrations/20250827121000_fix_security_invoker_and_search_path.sql
@@ -1,0 +1,64 @@
+-- Fix sécurité: activer security_invoker sur la vue et pinner le search_path des fonctions
+-- Contexte: Lints 0010_security_definer_view (ERROR) et 0011_function_search_path_mutable (WARN)
+
+BEGIN;
+
+-- 1) Vue: faire respecter les RLS via security_invoker
+ALTER VIEW public.v_unified_search_stats
+  SET (security_invoker = true);
+
+-- 2) Fonction: sync_workspace_user_quotas — pinner le search_path et qualifier les références
+CREATE OR REPLACE FUNCTION public.sync_workspace_user_quotas(target_workspace_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    user_record RECORD;
+    updated_count INTEGER := 0;
+BEGIN
+    -- Utiliser public.user_roles et auth.users explicitement
+    FOR user_record IN 
+        SELECT ur.user_id 
+        FROM public.user_roles ur
+        JOIN auth.users au ON ur.user_id = au.id  -- Uniquement utilisateurs valides
+        WHERE ur.workspace_id = target_workspace_id
+    LOOP
+        PERFORM public.update_user_quotas_from_workspace(user_record.user_id);
+        updated_count := updated_count + 1;
+    END LOOP;
+
+    RETURN updated_count;
+END;
+$$;
+
+-- 3) Fonction placeholder: refresh_emission_factors_teaser_public_fr — pinner le search_path si elle existe
+DO $block$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'refresh_emission_factors_teaser_public_fr'
+  ) THEN
+    EXECUTE $fn$
+      CREATE OR REPLACE FUNCTION public.refresh_emission_factors_teaser_public_fr()
+      RETURNS void
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = ''
+      AS $body$
+      BEGIN
+        -- Fonction temporaire pour compatibilité; pas d'effet
+        RETURN;
+      END;
+      $body$;
+    $fn$;
+  END IF;
+END
+$block$;
+
+COMMIT;
+
+


### PR DESCRIPTION
## 🔒 Fix des alertes de sécurité Supabase

### Problèmes résolus
- **Lint 0010_security_definer_view (ERROR)**: Vue `public.v_unified_search_stats` convertie en `security_invoker` pour respecter les politiques RLS
- **Lint 0011_function_search_path_mutable (WARN)**: Fonctions avec `search_path` figé à `''` et références explicitement qualifiées

### Modifications
- Migration `20250827121000_fix_security_invoker_and_search_path.sql` appliquée
- Vue `v_unified_search_stats` : `ALTER VIEW SET (security_invoker = true)`
- Fonction `sync_workspace_user_quotas()` : `SET search_path = ''` + schémas qualifiés
- Fonction `refresh_emission_factors_teaser_public_fr()` : sécurisée (placeholder maintenu)

### Résultat
✅ Aucune alerte de sécurité restante  
ℹ️ Seuls des warnings "unused_index" (INFO) subsistent - pas d'action obligatoire

### Tests
- Migration appliquée avec succès sur Supabase
- Avis de sécurité vérifiés : 0 erreur, 0 warning
- Fonctionnalités préservées