### PR TITLE
Refonte imports (v2): alignement users/admin, migrations persistantes, squash companies

### DIFF
--- a/supabase/migrations/20250728000100_ensure_companies_stub.sql
+++ b/supabase/migrations/20250728000100_ensure_companies_stub.sql
@@ -1,0 +1,16 @@
+-- Guard: ensure legacy companies table exists to satisfy subsequent DROP POLICY statements
+-- This stub will be safely dropped by later cleanup migrations if present
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables 
+    WHERE table_schema='public' AND table_name='companies'
+  ) THEN
+    CREATE TABLE public.companies (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      name text,
+      owner_id uuid,
+      plan_type text DEFAULT 'freemium'
+    );
+    ALTER TABLE public.companies ENABLE ROW LEVEL SECURITY;
+  END IF;
+END $$;

--- a/supabase/migrations/20250903_squash_remove_companies_references.sql
+++ b/supabase/migrations/20250903_squash_remove_companies_references.sql
@@ -1,0 +1,35 @@
+-- Squash cleanup: neutralize legacy references to public.companies
+-- 1) Drop policies if table exists
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='companies') THEN
+    -- Policies commonly seen across legacy files
+    EXECUTE 'DROP POLICY IF EXISTS "Users can create companies" ON public.companies';
+    EXECUTE 'DROP POLICY IF EXISTS "Owners can update their companies" ON public.companies';
+    EXECUTE 'DROP POLICY IF EXISTS "Users can view their own companies" ON public.companies';
+  END IF;
+END $$;
+
+-- 2) Guard: update legacy policies on user_roles/datasets that referenced companies without failing
+DO $$ BEGIN
+  -- user_roles
+  BEGIN
+    EXECUTE 'DROP POLICY IF EXISTS "Users can view roles in their companies" ON public.user_roles';
+  EXCEPTION WHEN undefined_table THEN
+    -- ignore
+  END;
+  -- datasets
+  BEGIN
+    EXECUTE 'DROP POLICY IF EXISTS "Users can create datasets in their companies" ON public.datasets';
+    EXECUTE 'DROP POLICY IF EXISTS "Users can update datasets in their companies" ON public.datasets';
+    EXECUTE 'DROP POLICY IF EXISTS "Users can view datasets in their companies" ON public.datasets';
+  EXCEPTION WHEN undefined_table THEN
+    -- ignore
+  END;
+END $$;
+
+-- 3) Finally drop companies table if still present
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='companies') THEN
+    DROP TABLE public.companies CASCADE;
+  END IF;
+END $$;


### PR DESCRIPTION
Cette PR v2 est basée sur main à jour et inclut:

- Alignement des imports users sur le pipeline robuste (chunked-upload → create-chunks → queue → process-csv-chunk → finalize) avec suivi via `user_import_status` et sync Algolia incrémentale ciblée.
- Import admin: finalisation atomique via `finalize_completed_imports` → `reindex-ef-all-atomic`.
- Migrations persistantes:
  - `20250903_align_user_imports.sql`
  - `20250903_align_admin_imports.sql`
  - Squash legacy `companies`:
    - `20250728000100_ensure_companies_stub.sql` (guard)
    - `20250903_squash_remove_companies_references.sql` (neutralisation + drop final)
- Docs API mises à jour (`docs/api/edge-function-api.md`):
  - Utiliser `chunked-upload` pour users/admin
  - Suivi: `import_status`/`user_import_status`
  - Dépréciation/suppression `import-csv-user`

Tests à faire:
1) /import (user): CSV.gz + dataset_name → job créé, progression/ETA, sync Algolia incrémentale.
2) Admin: job → finalize → reindex-ef-all-atomic OK.
3) Migrations: passage sur env vierge (bot Supabase) sans 42P01.
