### PR TITLE
fix(projection): champs EN + languages corrects; docs(import-cli)

### DIFF
--- a/supabase/migrations/20250904_fix_projection_languages_en.sql
+++ b/supabase/migrations/20250904_fix_projection_languages_en.sql
@@ -1,0 +1,125 @@
+-- Corriger la projection ef_all: champs EN et tableau languages correct
+-- Rebuild complet
+CREATE OR REPLACE FUNCTION public.rebuild_emission_factors_all_search()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM set_config('statement_timeout', '0', true);
+
+  TRUNCATE TABLE public.emission_factors_all_search;
+
+  INSERT INTO public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  SELECT
+    COALESCE(ef.stable_id, ef.id) AS object_id,
+    ef.id AS record_id,
+    CASE WHEN ef.workspace_id IS NULL THEN 'public' ELSE 'private' END AS scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      SELECT array_agg(ws.workspace_id)
+      FROM public.fe_source_workspace_assignments ws
+      WHERE ws.source_name = ef."Source"
+    ) AS assigned_workspace_ids,
+    ARRAY_REMOVE(ARRAY[
+      CASE WHEN (ef."Nom" IS NOT NULL OR ef."Description" IS NOT NULL OR ef."Unité donnée d'activité" IS NOT NULL OR ef."Secteur" IS NOT NULL OR ef."Localisation" IS NOT NULL) THEN 'fr' END,
+      CASE WHEN (ef."Nom_en" IS NOT NULL OR ef."Description_en" IS NOT NULL OR ef."Unite_en" IS NOT NULL OR ef."Secteur_en" IS NOT NULL OR ef."Localisation_en" IS NOT NULL) THEN 'en' END
+    ], NULL)::text[] AS languages,
+    ef."Nom"                AS "Nom_fr",
+    ef."Description"        AS "Description_fr",
+    ef."Commentaires"       AS "Commentaires_fr",
+    ef."Secteur"            AS "Secteur_fr",
+    ef."Sous-secteur"       AS "Sous-secteur_fr",
+    ef."Périmètre"          AS "Périmètre_fr",
+    ef."Localisation"       AS "Localisation_fr",
+    ef."Unité donnée d'activité" AS "Unite_fr",
+    ef."Nom_en"             AS "Nom_en",
+    ef."Description_en"     AS "Description_en",
+    ef."Commentaires_en"    AS "Commentaires_en",
+    ef."Secteur_en"         AS "Secteur_en",
+    ef."Sous-secteur_en"    AS "Sous-secteur_en",
+    ef."Périmètre_en"       AS "Périmètre_en",
+    ef."Localisation_en"    AS "Localisation_en",
+    ef."Unite_en"           AS "Unite_en",
+    NULLIF(ef."FE", '')::numeric AS "FE",
+    CASE WHEN ef."Date" ~ '^\d+$' THEN ef."Date"::integer ELSE NULL END AS "Date",
+    ef."Incertitude"        AS "Incertitude",
+    ef."Source"             AS "Source"
+  FROM public.emission_factors ef
+  JOIN public.fe_sources fs ON fs.source_name = ef."Source"
+  WHERE ef.is_latest = true;
+
+  RAISE NOTICE 'ef_all projection rebuilt: % rows', (SELECT count(*) FROM public.emission_factors_all_search);
+END;
+$$;
+
+-- Refresh par source (utilisé par le pipeline)
+CREATE OR REPLACE FUNCTION public.refresh_ef_all_for_source(p_source text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_source IS NULL OR length(p_source) = 0 THEN
+    RAISE NOTICE 'refresh_ef_all_for_source: source vide';
+    RETURN;
+  END IF;
+
+  DELETE FROM public.emission_factors_all_search WHERE "Source" = p_source;
+
+  INSERT INTO public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  SELECT
+    COALESCE(ef.stable_id, ef.id) AS object_id,
+    ef.id AS record_id,
+    CASE WHEN ef.workspace_id IS NULL THEN 'public' ELSE 'private' END AS scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      SELECT array_agg(ws.workspace_id)
+      FROM public.fe_source_workspace_assignments ws
+      WHERE ws.source_name = ef."Source"
+    ) AS assigned_workspace_ids,
+    ARRAY_REMOVE(ARRAY[
+      CASE WHEN (ef."Nom" IS NOT NULL OR ef."Description" IS NOT NULL OR ef."Unité donnée d'activité" IS NOT NULL OR ef."Secteur" IS NOT NULL OR ef."Localisation" IS NOT NULL) THEN 'fr' END,
+      CASE WHEN (ef."Nom_en" IS NOT NULL OR ef."Description_en" IS NOT NULL OR ef."Unite_en" IS NOT NULL OR ef."Secteur_en" IS NOT NULL OR ef."Localisation_en" IS NOT NULL) THEN 'en' END
+    ], NULL)::text[] AS languages,
+    ef."Nom"                AS "Nom_fr",
+    ef."Description"        AS "Description_fr",
+    ef."Commentaires"       AS "Commentaires_fr",
+    ef."Secteur"            AS "Secteur_fr",
+    ef."Sous-secteur"       AS "Sous-secteur_fr",
+    ef."Périmètre"          AS "Périmètre_fr",
+    ef."Localisation"       AS "Localisation_fr",
+    ef."Unité donnée d'activité" AS "Unite_fr",
+    ef."Nom_en"             AS "Nom_en",
+    ef."Description_en"     AS "Description_en",
+    ef."Commentaires_en"    AS "Commentaires_en",
+    ef."Secteur_en"         AS "Secteur_en",
+    ef."Sous-secteur_en"    AS "Sous-secteur_en",
+    ef."Périmètre_en"       AS "Périmètre_en",
+    ef."Localisation_en"    AS "Localisation_en",
+    ef."Unite_en"           AS "Unite_en",
+    NULLIF(ef."FE", '')::numeric AS "FE",
+    CASE WHEN ef."Date" ~ '^\d+$' THEN ef."Date"::integer ELSE NULL END AS "Date",
+    ef."Incertitude"        AS "Incertitude",
+    ef."Source"             AS "Source"
+  FROM public.emission_factors ef
+  JOIN public.fe_sources fs ON fs.source_name = ef."Source"
+  WHERE ef.is_latest = true AND ef."Source" = p_source;
+
+  RAISE NOTICE 'ef_all refreshed for source: %', p_source;
+END;
+$$;


### PR DESCRIPTION
Résumé
- Corrige la projection `emission_factors_all_search` :
  - mapping des champs *_en depuis `public.emission_factors`
  - `languages` désormais `['fr']`, `['en']` ou `['fr','en']` selon présence des colonnes FR/EN
  - rebuild/refresh mis à jour (évite les casts fragiles)
- Ajoute `scripts/README_import_cli.md` (prérequis, usage, reprise via STAGING_OVERRIDE, troubleshooting)
- Nettoie le script d’import: plus d’étape Algolia (connecteur natif gère l’indexation)

Fichiers clés
- supabase/migrations/20250904_fix_projection_languages_en.sql (et versions ultérieures)
- scripts/import-and-reindex.sh
- scripts/csv-header-to-sql.js
- scripts/csv-header-columns.js
- scripts/README_import_cli.md

Tests manuels
- Rebuild exécuté avec succès ; `emission_factors_all_search` ≈ 192k lignes
- Delta attendu < 10 vs `is_latest=true` (données invalides FE/Date ignorées)

Suivi
- L’indexation Algolia est déclenchée via le connecteur Algolia↔Supabase (plus aucune étape côté repo)
