### PR TITLE
Overlays utilisateurs + projection unifiée ef_all_search (prévention overwrite)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,10 +24,67 @@ Cette documentation couvre la nouvelle architecture de recherche unifiée déplo
 - Tests de sécurité et conformité
 - **Lecture recommandée** : Équipe sécurité et développeurs
 
-### 🔌 Imports de données (nouveau)
-- Users: 100% DB → RunTask EU après import
-- Admin: Dataiku → run_import_from_staging() → RunTask EU
-- Voir README ci‑dessous
+### 🧩 Imports de données (nouveau)
+
+- Users (100% DB):
+  - Edge Function `import-csv-user` lit le CSV (CSV/XLSX/CSV.GZ), parse robuste, upsert via RPC `batch_upsert_user_factor_overlays` dans `public.user_factor_overlays` (unicité (workspace_id, factor_key)).
+  - Refresh ciblé: `select public.refresh_ef_all_for_source(datasetName);` (projection unifiée admin + overlays).
+  - Ingestion: déclenchement DB `select public.trigger_algolia_users_ingestion(workspace_id);` (RunTask EU côté connector).
+
+- Admin (Dataiku):
+  - Push dans `public.staging_emission_factors` (colonnes texte 1:1 avec CSV).
+  - `select public.run_import_from_staging();` (SCD1 sur `public.emission_factors`, puis refresh unifié par source et RunTask EU admin).
+
+- Clé fonctionnelle: `public.calculate_factor_key(nom, unite, source, perimetre, localisation, fe, date)`
+  - Tous champs optionnels sauf `FE` et `Unité donnée d'activité`.
+  - `factor_key` identique entre admin et users → partitionnement logique par table; overlays users utilisent `(workspace_id, factor_key)` unique.
+
+### 🗃️ Modèle de données
+
+- Table admin: `public.emission_factors` (SCD1 sur `factor_key`, `is_latest=true`).
+- Table overlays users: `public.user_factor_overlays`
+  - Colonnes texte alignées sur le CSV bilingue; `overlay_id` UUID PK; `workspace_id` UUID; `dataset_name` text; `factor_key` text; timestamps.
+  - Index unique: `(workspace_id, factor_key)`.
+
+- Projection unifiée: `public.emission_factors_all_search`
+  - Rebuild/refresh intègrent `emission_factors` (admin) + `user_factor_overlays` (users).
+  - Champs i18n: `Nom_fr/Unite_fr/...` et `Nom_en/Unite_en/...`, `languages` text[] construit dynamiquement.
+
+### 🛠️ RPC / Fonctions
+
+- `public.batch_upsert_user_factor_overlays(p_workspace_id uuid, p_dataset_name text, p_records jsonb) returns jsonb`
+  - Upsert SCD1 par `(workspace_id, factor_key)`, typage sécurisé FE/Date.
+  - Retour `{ inserted, updated }`.
+
+- `public.refresh_ef_all_for_source(p_source text)` et `public.rebuild_emission_factors_all_search()`
+  - Suppriment et réinsèrent depuis admin + overlays.
+
+- `public.run_import_from_staging()`
+  - Prépare/normalise, déduplique (`factor_key`), upsert admin, refresh par source, puis `run_algolia_data_task` (EU) pour la task admin.
+
+### 🔌 Edge Function
+
+- `import-csv-user` (JWT requis)
+  - Parse robuste, validation headers, upsert RPC overlays, refresh projection pour `datasetName`, déclenche `trigger_algolia_users_ingestion(workspace_id)`.
+
+### 🧭 Migrations à appliquer
+
+1) Overlays + RPC
+- `20250910_user_overlays_and_unified_projection.sql` (table, index, RPC initiale).
+- `20250910_fix_batch_upsert_user_overlays.sql` (fix ambiguïté workspace_id).
+
+2) Projection unifiée
+- `20250910_unify_projection_with_overlays.sql` (rebuild/refresh unifiés).
+
+3) Backfill
+- `20250910_backfill_users_to_overlays.sql` (copie des enregistrements privés existants vers overlays).
+
+Aucune opération de rebuild globale n'est nécessaire immédiatement; les fonctions de refresh seront invoquées par flux.
+
+### 🔐 Supabase (sécurité / extensions)
+
+- Extensions: `pgcrypto` (UUID génération), `pg_net` (déjà utilisé pour RunTask via DB).
+- Rôles/accès: la RPC `batch_upsert_user_factor_overlays` est `SECURITY DEFINER`; scoper les `GRANT EXECUTE` selon besoin.
 
 ### ⚛️ [Intégration Frontend](./frontend/integration-guide.md)
 - Guide d'utilisation des composants React

--- a/src/pages/Import.tsx
+++ b/src/pages/Import.tsx
@@ -33,7 +33,7 @@ const Import = () => {
 
   const downloadTemplate = () => {
     const headers = [
-      'id','nom','nom_en','description','description_en','fe','unite','unite_en','source','secteur','secteur_en','categorie','categorie_en','localisation','localisation_en','date','incertitude','perimetre','perimetre_en','contributeur','commentaires','commentaires_en'
+      'ID','Nom','Nom_en','Description','Description_en','FE',"Unité donnée d'activité",'Unite_en','Source','Secteur','Secteur_en','Sous-secteur','Sous-secteur_en','Localisation','Localisation_en','Date','Incertitude','Périmètre','Périmètre_en','Contributeur','Commentaires','Commentaires_en'
     ];
     const row = [
       '',
@@ -53,7 +53,7 @@ const Import = () => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'template_facteurs_emissions_bilingue.csv';
+    a.download = 'template_facteurs_emissions.csv';
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -449,8 +449,7 @@ const Import = () => {
                 </div>
                 
                 <div className="mt-4 text-sm text-muted-foreground">
-                  <strong>Colonnes requises :</strong> nom, description, fe, unite, source, secteur, 
-                  categorie, localisation, date, incertitude
+                  <strong>Colonnes requises :</strong> Nom, Description, FE, "Unité donnée d'activité", Source, Secteur, Sous-secteur, Localisation, Date, Incertitude, Périmètre
                 </div>
               </CardContent>
             </Card>

--- a/supabase/migrations/20250910_backfill_users_to_overlays.sql
+++ b/supabase/migrations/20250910_backfill_users_to_overlays.sql
@@ -1,0 +1,23 @@
+-- Backfill des données users existantes (si des imports utilisateurs résident encore dans emission_factors)
+begin;
+
+-- Insérer dans overlays les lignes privées existantes (si elles existaient)
+insert into public.user_factor_overlays (
+  workspace_id, dataset_name, factor_key,
+  "ID","Nom","Nom_en","Description","Description_en","FE","Unité donnée d'activité","Unite_en","Source",
+  "Secteur","Secteur_en","Sous-secteur","Sous-secteur_en","Localisation","Localisation_en","Date","Incertitude",
+  "Périmètre","Périmètre_en","Contributeur","Commentaires","Commentaires_en"
+)
+select 
+  ef.workspace_id,
+  coalesce(ef."Source", 'import_utilisateur') as dataset_name,
+  ef.factor_key,
+  ef."ID",ef."Nom",ef."Nom_en",ef."Description",ef."Description_en",ef."FE",ef."Unité donnée d'activité",ef."Unite_en",ef."Source",
+  ef."Secteur",ef."Secteur_en",ef."Sous-secteur",ef."Sous-secteur_en",ef."Localisation",ef."Localisation_en",ef."Date",ef."Incertitude",
+  ef."Périmètre",ef."Périmètre_en",ef."Contributeur",ef."Commentaires",ef."Commentaires_en"
+from public.emission_factors ef
+where ef.is_latest = true and ef.workspace_id is not null
+on conflict (workspace_id, factor_key) do nothing;
+
+commit;
+

--- a/supabase/migrations/20250910_fix_batch_upsert_user_overlays.sql
+++ b/supabase/migrations/20250910_fix_batch_upsert_user_overlays.sql
@@ -1,0 +1,169 @@
+-- Corrige l'ambiguïté de colonne dans batch_upsert_user_factor_overlays
+begin;
+
+create or replace function public.batch_upsert_user_factor_overlays(
+  p_workspace_id uuid,
+  p_dataset_name text,
+  p_records jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_inserted int := 0;
+  v_updated int := 0;
+begin
+  if p_records is null or jsonb_typeof(p_records) <> 'array' then
+    raise exception 'p_records doit être un tableau JSON';
+  end if;
+
+  with incoming as (
+    select 
+      p_workspace_id as workspace_id,
+      p_dataset_name as dataset_name,
+      (rec->>'ID') as "ID",
+      (rec->>'Nom') as "Nom",
+      (rec->>'Nom_en') as "Nom_en",
+      (rec->>'Description') as "Description",
+      (rec->>'Description_en') as "Description_en",
+      (rec->>'FE') as "FE",
+      (rec->>'Unité donnée d''activité') as "Unité donnée d'activité",
+      (rec->>'Unite_en') as "Unite_en",
+      (rec->>'Source') as "Source",
+      (rec->>'Secteur') as "Secteur",
+      (rec->>'Secteur_en') as "Secteur_en",
+      (rec->>'Sous-secteur') as "Sous-secteur",
+      (rec->>'Sous-secteur_en') as "Sous-secteur_en",
+      (rec->>'Localisation') as "Localisation",
+      (rec->>'Localisation_en') as "Localisation_en",
+      (rec->>'Date') as "Date",
+      (rec->>'Incertitude') as "Incertitude",
+      (rec->>'Périmètre') as "Périmètre",
+      (rec->>'Périmètre_en') as "Périmètre_en",
+      (rec->>'Contributeur') as "Contributeur",
+      (rec->>'Commentaires') as "Commentaires",
+      (rec->>'Commentaires_en') as "Commentaires_en"
+    from jsonb_array_elements(p_records) as rec
+  ), prepared as (
+    select
+      incoming.workspace_id,
+      incoming.dataset_name,
+      incoming."ID",
+      incoming."Nom",
+      incoming."Nom_en",
+      incoming."Description",
+      incoming."Description_en",
+      incoming."FE",
+      incoming."Unité donnée d'activité",
+      incoming."Unite_en",
+      incoming."Source",
+      incoming."Secteur",
+      incoming."Secteur_en",
+      incoming."Sous-secteur",
+      incoming."Sous-secteur_en",
+      incoming."Localisation",
+      incoming."Localisation_en",
+      incoming."Date",
+      incoming."Incertitude",
+      incoming."Périmètre",
+      incoming."Périmètre_en",
+      incoming."Contributeur",
+      incoming."Commentaires",
+      incoming."Commentaires_en",
+      public.safe_to_numeric(nullif(incoming."FE", '')) as fe_num,
+      case when trim(coalesce(incoming."Date",'')) ~ '^\d+$' then trim(incoming."Date")::int else null end as date_int,
+      coalesce(nullif(incoming."Nom", ''), nullif(incoming."Nom_en", '')) as nom,
+      coalesce(nullif(incoming."Unité donnée d'activité", ''), null) as unite,
+      coalesce(nullif(incoming."Source", ''), null) as source,
+      coalesce(nullif(incoming."Périmètre", ''), nullif(incoming."Périmètre_en", '')) as perimetre,
+      coalesce(nullif(incoming."Localisation", ''), nullif(incoming."Localisation_en", '')) as localisation
+    from incoming
+  ), keyed as (
+    select 
+      prepared.workspace_id,
+      prepared.dataset_name,
+      prepared."ID",
+      prepared."Nom",
+      prepared."Nom_en",
+      prepared."Description",
+      prepared."Description_en",
+      prepared."FE",
+      prepared."Unité donnée d'activité",
+      prepared."Unite_en",
+      prepared."Source",
+      prepared."Secteur",
+      prepared."Secteur_en",
+      prepared."Sous-secteur",
+      prepared."Sous-secteur_en",
+      prepared."Localisation",
+      prepared."Localisation_en",
+      prepared."Date",
+      prepared."Incertitude",
+      prepared."Périmètre",
+      prepared."Périmètre_en",
+      prepared."Contributeur",
+      prepared."Commentaires",
+      prepared."Commentaires_en",
+      public.calculate_factor_key(
+        p_nom := prepared.nom,
+        p_unite := prepared.unite,
+        p_source := prepared.source,
+        p_perimetre := prepared.perimetre,
+        p_localisation := prepared.localisation,
+        p_workspace_id := null,
+        p_language := null,
+        p_fe := prepared.fe_num,
+        p_date := prepared.date_int
+      ) as factor_key
+    from prepared
+  ), upsert as (
+    insert into public.user_factor_overlays as ufo (
+      workspace_id, dataset_name, factor_key,
+      "ID","Nom","Nom_en","Description","Description_en","FE","Unité donnée d'activité","Unite_en","Source",
+      "Secteur","Secteur_en","Sous-secteur","Sous-secteur_en","Localisation","Localisation_en","Date","Incertitude",
+      "Périmètre","Périmètre_en","Contributeur","Commentaires","Commentaires_en", updated_at
+    )
+    select
+      keyed.workspace_id, keyed.dataset_name, keyed.factor_key,
+      keyed."ID",keyed."Nom",keyed."Nom_en",keyed."Description",keyed."Description_en",keyed."FE",keyed."Unité donnée d'activité",keyed."Unite_en",keyed."Source",
+      keyed."Secteur",keyed."Secteur_en",keyed."Sous-secteur",keyed."Sous-secteur_en",keyed."Localisation",keyed."Localisation_en",keyed."Date",keyed."Incertitude",
+      keyed."Périmètre",keyed."Périmètre_en",keyed."Contributeur",keyed."Commentaires",keyed."Commentaires_en", now()
+    from keyed
+    where keyed.factor_key is not null
+    on conflict (workspace_id, factor_key) do update
+      set 
+        dataset_name = excluded.dataset_name,
+        "ID" = excluded."ID",
+        "Nom" = excluded."Nom",
+        "Nom_en" = excluded."Nom_en",
+        "Description" = excluded."Description",
+        "Description_en" = excluded."Description_en",
+        "FE" = excluded."FE",
+        "Unité donnée d'activité" = excluded."Unité donnée d'activité",
+        "Unite_en" = excluded."Unite_en",
+        "Source" = excluded."Source",
+        "Secteur" = excluded."Secteur",
+        "Secteur_en" = excluded."Secteur_en",
+        "Sous-secteur" = excluded."Sous-secteur",
+        "Sous-secteur_en" = excluded."Sous-secteur_en",
+        "Localisation" = excluded."Localisation",
+        "Localisation_en" = excluded."Localisation_en",
+        "Date" = excluded."Date",
+        "Incertitude" = excluded."Incertitude",
+        "Périmètre" = excluded."Périmètre",
+        "Périmètre_en" = excluded."Périmètre_en",
+        "Contributeur" = excluded."Contributeur",
+        "Commentaires" = excluded."Commentaires",
+        "Commentaires_en" = excluded."Commentaires_en",
+        updated_at = now()
+    returning (xmax = 0) as inserted
+  )
+  select count(*) filter (where inserted), count(*) filter (where not inserted) into v_inserted, v_updated from upsert;
+
+  return jsonb_build_object('inserted', v_inserted, 'updated', v_updated);
+end $$;
+
+commit;
+
+

--- a/supabase/migrations/20250910_unify_projection_with_overlays.sql
+++ b/supabase/migrations/20250910_unify_projection_with_overlays.sql
@@ -1,0 +1,221 @@
+-- Unifier la projection emission_factors_all_search (admin + overlays users)
+begin;
+
+create or replace function public.rebuild_emission_factors_all_search()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform set_config('statement_timeout', '0', true);
+
+  truncate table public.emission_factors_all_search;
+
+  -- Admin (base commune) depuis public.emission_factors
+  insert into public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  select
+    coalesce(ef.id, gen_random_uuid()) as object_id,
+    ef.id as record_id,
+    case when ef.workspace_id is null then 'public' else 'private' end as scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      select array_agg(ws.workspace_id)
+      from public.fe_source_workspace_assignments ws
+      where ws.source_name = ef."Source"
+    ) as assigned_workspace_ids,
+    array_remove(array[
+      case when (ef."Nom" is not null or ef."Description" is not null or ef."Unité donnée d'activité" is not null or ef."Secteur" is not null or ef."Localisation" is not null) then 'fr' end,
+      case when (ef."Nom_en" is not null or ef."Description_en" is not null or ef."Unite_en" is not null or ef."Secteur_en" is not null or ef."Localisation_en" is not null) then 'en' end
+    ], null)::text[] as languages,
+    ef."Nom"                as "Nom_fr",
+    ef."Description"        as "Description_fr",
+    ef."Commentaires"       as "Commentaires_fr",
+    ef."Secteur"            as "Secteur_fr",
+    ef."Sous-secteur"       as "Sous-secteur_fr",
+    ef."Périmètre"          as "Périmètre_fr",
+    ef."Localisation"       as "Localisation_fr",
+    ef."Unité donnée d'activité" as "Unite_fr",
+    ef."Nom_en"             as "Nom_en",
+    ef."Description_en"     as "Description_en",
+    ef."Commentaires_en"    as "Commentaires_en",
+    ef."Secteur_en"         as "Secteur_en",
+    ef."Sous-secteur_en"    as "Sous-secteur_en",
+    ef."Périmètre_en"       as "Périmètre_en",
+    ef."Localisation_en"    as "Localisation_en",
+    ef."Unite_en"           as "Unite_en",
+    public.safe_to_numeric(coalesce(nullif(ef."FE"::text, ''), null)) as "FE",
+    case when trim(coalesce(ef."Date"::text,'')) ~ '^\d+$' then ef."Date"::integer else null end as "Date",
+    ef."Incertitude"        as "Incertitude",
+    ef."Source"             as "Source"
+  from public.emission_factors ef
+  join public.fe_sources fs on fs.source_name = ef."Source"
+  where ef.is_latest = true;
+
+  -- Overlays users
+  insert into public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  select
+    ufo.overlay_id as object_id,
+    ufo.overlay_id as record_id,
+    'private' as scope,
+    ufo.workspace_id,
+    coalesce(fs.access_level, 'standard') as access_level,
+    (
+      select array_agg(ws.workspace_id)
+      from public.fe_source_workspace_assignments ws
+      where ws.source_name = ufo."Source"
+    ) as assigned_workspace_ids,
+    array_remove(array[
+      case when (ufo."Nom" is not null or ufo."Description" is not null or ufo."Unité donnée d'activité" is not null or ufo."Secteur" is not null or ufo."Localisation" is not null) then 'fr' end,
+      case when (ufo."Nom_en" is not null or ufo."Description_en" is not null or ufo."Unite_en" is not null or ufo."Secteur_en" is not null or ufo."Localisation_en" is not null) then 'en' end
+    ], null)::text[] as languages,
+    ufo."Nom"                as "Nom_fr",
+    ufo."Description"        as "Description_fr",
+    ufo."Commentaires"       as "Commentaires_fr",
+    ufo."Secteur"            as "Secteur_fr",
+    ufo."Sous-secteur"       as "Sous-secteur_fr",
+    ufo."Périmètre"          as "Périmètre_fr",
+    ufo."Localisation"       as "Localisation_fr",
+    ufo."Unité donnée d'activité" as "Unite_fr",
+    ufo."Nom_en"             as "Nom_en",
+    ufo."Description_en"     as "Description_en",
+    ufo."Commentaires_en"    as "Commentaires_en",
+    ufo."Secteur_en"         as "Secteur_en",
+    ufo."Sous-secteur_en"    as "Sous-secteur_en",
+    ufo."Périmètre_en"       as "Périmètre_en",
+    ufo."Localisation_en"    as "Localisation_en",
+    ufo."Unite_en"           as "Unite_en",
+    public.safe_to_numeric(coalesce(nullif(ufo."FE", ''), null)) as "FE",
+    case when trim(coalesce(ufo."Date",'')) ~ '^\d+$' then trim(ufo."Date")::integer else null end as "Date",
+    ufo."Incertitude"        as "Incertitude",
+    ufo."Source"             as "Source"
+  from public.user_factor_overlays ufo
+  left join public.fe_sources fs on fs.source_name = ufo."Source";
+
+  raise notice 'ef_all projection (unifiée) rebuilt: % rows', (select count(*) from public.emission_factors_all_search);
+end;
+$$;
+
+create or replace function public.refresh_ef_all_for_source(p_source text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_source is null or length(p_source) = 0 then
+    raise notice 'refresh_ef_all_for_source: source vide';
+    return;
+  end if;
+
+  delete from public.emission_factors_all_search where "Source" = p_source;
+
+  -- Admin (par source)
+  insert into public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  select
+    coalesce(ef.id, gen_random_uuid()) as object_id,
+    ef.id as record_id,
+    case when ef.workspace_id is null then 'public' else 'private' end as scope,
+    ef.workspace_id,
+    fs.access_level,
+    (
+      select array_agg(ws.workspace_id)
+      from public.fe_source_workspace_assignments ws
+      where ws.source_name = ef."Source"
+    ) as assigned_workspace_ids,
+    array_remove(array[
+      case when (ef."Nom" is not null or ef."Description" is not null or ef."Unité donnée d'activité" is not null or ef."Secteur" is not null or ef."Localisation" is not null) then 'fr' end,
+      case when (ef."Nom_en" is not null or ef."Description_en" is not null or ef."Unite_en" is not null or ef."Secteur_en" is not null or ef."Localisation_en" is not null) then 'en' end
+    ], null)::text[] as languages,
+    ef."Nom"                as "Nom_fr",
+    ef."Description"        as "Description_fr",
+    ef."Commentaires"       as "Commentaires_fr",
+    ef."Secteur"            as "Secteur_fr",
+    ef."Sous-secteur"       as "Sous-secteur_fr",
+    ef."Périmètre"          as "Périmètre_fr",
+    ef."Localisation"       as "Localisation_fr",
+    ef."Unité donnée d'activité" as "Unite_fr",
+    ef."Nom_en"             as "Nom_en",
+    ef."Description_en"     as "Description_en",
+    ef."Commentaires_en"    as "Commentaires_en",
+    ef."Secteur_en"         as "Secteur_en",
+    ef."Sous-secteur_en"    as "Sous-secteur_en",
+    ef."Périmètre_en"       as "Périmètre_en",
+    ef."Localisation_en"    as "Localisation_en",
+    ef."Unite_en"           as "Unite_en",
+    public.safe_to_numeric(coalesce(nullif(ef."FE"::text, ''), null)) as "FE",
+    case when trim(coalesce(ef."Date"::text,'')) ~ '^\d+$' then ef."Date"::integer else null end as "Date",
+    ef."Incertitude"        as "Incertitude",
+    ef."Source"             as "Source"
+  from public.emission_factors ef
+  join public.fe_sources fs on fs.source_name = ef."Source"
+  where ef.is_latest = true and ef."Source" = p_source;
+
+  -- Overlays (par source)
+  insert into public.emission_factors_all_search (
+    object_id, record_id, scope, workspace_id, access_level, assigned_workspace_ids, languages,
+    "Nom_fr","Description_fr","Commentaires_fr","Secteur_fr","Sous-secteur_fr","Périmètre_fr","Localisation_fr","Unite_fr",
+    "Nom_en","Description_en","Commentaires_en","Secteur_en","Sous-secteur_en","Périmètre_en","Localisation_en","Unite_en",
+    "FE","Date","Incertitude","Source"
+  )
+  select
+    ufo.overlay_id as object_id,
+    ufo.overlay_id as record_id,
+    'private' as scope,
+    ufo.workspace_id,
+    coalesce(fs.access_level, 'standard') as access_level,
+    (
+      select array_agg(ws.workspace_id)
+      from public.fe_source_workspace_assignments ws
+      where ws.source_name = ufo."Source"
+    ) as assigned_workspace_ids,
+    array_remove(array[
+      case when (ufo."Nom" is not null or ufo."Description" is not null or ufo."Unité donnée d'activité" is not null or ufo."Secteur" is not null or ufo."Localisation" is not null) then 'fr' end,
+      case when (ufo."Nom_en" is not null or ufo."Description_en" is not null or ufo."Unite_en" is not null or ufo."Secteur_en" is not null or ufo."Localisation_en" is not null) then 'en' end
+    ], null)::text[] as languages,
+    ufo."Nom"                as "Nom_fr",
+    ufo."Description"        as "Description_fr",
+    ufo."Commentaires"       as "Commentaires_fr",
+    ufo."Secteur"            as "Secteur_fr",
+    ufo."Sous-secteur"       as "Sous-secteur_fr",
+    ufo."Périmètre"          as "Périmètre_fr",
+    ufo."Localisation"       as "Localisation_fr",
+    ufo."Unité donnée d'activité" as "Unite_fr",
+    ufo."Nom_en"             as "Nom_en",
+    ufo."Description_en"     as "Description_en",
+    ufo."Commentaires_en"    as "Commentaires_en",
+    ufo."Secteur_en"         as "Secteur_en",
+    ufo."Sous-secteur_en"    as "Sous-secteur_en",
+    ufo."Périmètre_en"       as "Périmètre_en",
+    ufo."Localisation_en"    as "Localisation_en",
+    ufo."Unite_en"           as "Unite_en",
+    public.safe_to_numeric(coalesce(nullif(ufo."FE", ''), null)) as "FE",
+    case when trim(coalesce(ufo."Date",'')) ~ '^\d+$' then trim(ufo."Date")::integer else null end as "Date",
+    ufo."Incertitude"        as "Incertitude",
+    ufo."Source"             as "Source"
+  from public.user_factor_overlays ufo
+  left join public.fe_sources fs on fs.source_name = ufo."Source"
+  where ufo."Source" = p_source;
+
+  raise notice 'ef_all refreshed for source: %', p_source;
+end;
+$$;
+
+commit;
+

--- a/supabase/migrations/20250910_user_overlays_and_unified_projection.sql
+++ b/supabase/migrations/20250910_user_overlays_and_unified_projection.sql
@@ -1,0 +1,174 @@
+-- Create overlays table for user imports and unify projection
+begin;
+
+-- Extensions nécessaires
+create extension if not exists pgcrypto;
+
+-- 1) Table overlays: stocke à vie les imports users (SCD1 par (workspace_id, factor_key))
+create table if not exists public.user_factor_overlays (
+  overlay_id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null,
+  dataset_name text,
+  factor_key text not null,
+  "ID" text,
+  "Nom" text,
+  "Nom_en" text,
+  "Description" text,
+  "Description_en" text,
+  "FE" text,
+  "Unité donnée d'activité" text,
+  "Unite_en" text,
+  "Source" text,
+  "Secteur" text,
+  "Secteur_en" text,
+  "Sous-secteur" text,
+  "Sous-secteur_en" text,
+  "Localisation" text,
+  "Localisation_en" text,
+  "Date" text,
+  "Incertitude" text,
+  "Périmètre" text,
+  "Périmètre_en" text,
+  "Contributeur" text,
+  "Commentaires" text,
+  "Commentaires_en" text,
+  scope text not null default 'private',
+  access_level text default 'standard',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Unicité côté users: un état courant par (workspace, factor_key)
+create unique index if not exists user_factor_overlays_workspace_factor_key_idx
+  on public.user_factor_overlays (workspace_id, factor_key);
+
+-- 2) RPC: batch_upsert_user_factor_overlays
+create or replace function public.batch_upsert_user_factor_overlays(
+  p_workspace_id uuid,
+  p_dataset_name text,
+  p_records jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_inserted int := 0;
+  v_updated int := 0;
+begin
+  if p_records is null or jsonb_typeof(p_records) <> 'array' then
+    raise exception 'p_records doit être un tableau JSON';
+  end if;
+
+  with incoming as (
+    select 
+      p_workspace_id as workspace_id,
+      p_dataset_name as dataset_name,
+      (rec->>'ID') as "ID",
+      (rec->>'Nom') as "Nom",
+      (rec->>'Nom_en') as "Nom_en",
+      (rec->>'Description') as "Description",
+      (rec->>'Description_en') as "Description_en",
+      (rec->>'FE') as "FE",
+      (rec->>'Unité donnée d'activité') as "Unité donnée d'activité",
+      (rec->>'Unite_en') as "Unite_en",
+      (rec->>'Source') as "Source",
+      (rec->>'Secteur') as "Secteur",
+      (rec->>'Secteur_en') as "Secteur_en",
+      (rec->>'Sous-secteur') as "Sous-secteur",
+      (rec->>'Sous-secteur_en') as "Sous-secteur_en",
+      (rec->>'Localisation') as "Localisation",
+      (rec->>'Localisation_en') as "Localisation_en",
+      (rec->>'Date') as "Date",
+      (rec->>'Incertitude') as "Incertitude",
+      (rec->>'Périmètre') as "Périmètre",
+      (rec->>'Périmètre_en') as "Périmètre_en",
+      (rec->>'Contributeur') as "Contributeur",
+      (rec->>'Commentaires') as "Commentaires",
+      (rec->>'Commentaires_en') as "Commentaires_en"
+    from jsonb_array_elements(p_records) as rec
+  ), prepared as (
+    select
+      workspace_id,
+      dataset_name,
+      -- FE/Date typage sécurisé pour la factor_key
+      public.safe_to_numeric(nullif("FE", '')) as fe_num,
+      case when trim(coalesce("Date",'')) ~ '^\d+$' then trim("Date")::int else null end as date_int,
+      coalesce(nullif("Nom", ''), nullif("Nom_en", '')) as nom,
+      coalesce(nullif("Unité donnée d'activité", ''), null) as unite,
+      coalesce(nullif("Source", ''), null) as source,
+      coalesce(nullif("Périmètre", ''), nullif("Périmètre_en", '')) as perimetre,
+      coalesce(nullif("Localisation", ''), nullif("Localisation_en", '')) as localisation,
+      *
+    from incoming
+  ), keyed as (
+    select *, public.calculate_factor_key(
+      p_nom := nom,
+      p_unite := unite,
+      p_source := source,
+      p_perimetre := perimetre,
+      p_localisation := localisation,
+      p_workspace_id := null,
+      p_language := null,
+      p_fe := fe_num,
+      p_date := date_int
+    ) as factor_key
+    from prepared
+  ), upsert as (
+    insert into public.user_factor_overlays as ufo (
+      workspace_id, dataset_name, factor_key,
+      "ID","Nom","Nom_en","Description","Description_en","FE","Unité donnée d'activité","Unite_en","Source",
+      "Secteur","Secteur_en","Sous-secteur","Sous-secteur_en","Localisation","Localisation_en","Date","Incertitude",
+      "Périmètre","Périmètre_en","Contributeur","Commentaires","Commentaires_en", updated_at
+    )
+    select
+      workspace_id, dataset_name, factor_key,
+      "ID","Nom","Nom_en","Description","Description_en","FE","Unité donnée d'activité","Unite_en","Source",
+      "Secteur","Secteur_en","Sous-secteur","Sous-secteur_en","Localisation","Localisation_en","Date","Incertitude",
+      "Périmètre","Périmètre_en","Contributeur","Commentaires","Commentaires_en", now()
+    from keyed
+    where factor_key is not null
+    on conflict (workspace_id, factor_key) do update
+      set 
+        dataset_name = excluded.dataset_name,
+        "ID" = excluded."ID",
+        "Nom" = excluded."Nom",
+        "Nom_en" = excluded."Nom_en",
+        "Description" = excluded."Description",
+        "Description_en" = excluded."Description_en",
+        "FE" = excluded."FE",
+        "Unité donnée d'activité" = excluded."Unité donnée d'activité",
+        "Unite_en" = excluded."Unite_en",
+        "Source" = excluded."Source",
+        "Secteur" = excluded."Secteur",
+        "Secteur_en" = excluded."Secteur_en",
+        "Sous-secteur" = excluded."Sous-secteur",
+        "Sous-secteur_en" = excluded."Sous-secteur_en",
+        "Localisation" = excluded."Localisation",
+        "Localisation_en" = excluded."Localisation_en",
+        "Date" = excluded."Date",
+        "Incertitude" = excluded."Incertitude",
+        "Périmètre" = excluded."Périmètre",
+        "Périmètre_en" = excluded."Périmètre_en",
+        "Contributeur" = excluded."Contributeur",
+        "Commentaires" = excluded."Commentaires",
+        "Commentaires_en" = excluded."Commentaires_en",
+        updated_at = now()
+    returning (xmax = 0) as inserted
+  )
+  select
+    count(*) filter (where inserted) into v_inserted,
+    count(*) filter (where not inserted) into v_updated
+  from upsert;
+
+  return jsonb_build_object('inserted', v_inserted, 'updated', v_updated);
+end $$;
+
+-- 3) Projection unifiée: rebuild/refresh (extrait minimal – suppose fonctions existantes)
+-- Exemple: remplacer les sélections sources dans rebuild_emission_factors_all_search()
+-- admin: from public.emission_factors where is_latest=true
+-- users: from public.user_factor_overlays
+-- ATTENTION: l’implémentation exacte dépend de la fonction existante; à adapter en place.
+
+commit;
+


### PR DESCRIPTION
Résumé
- Ajout de la table `public.user_factor_overlays` (unicité (workspace_id, factor_key))
- RPC `batch_upsert_user_factor_overlays(p_workspace_id, p_dataset_name, p_records)` pour ingestion users 100% DB
- Unification de la projection `public.emission_factors_all_search` (admin + overlays)
- Backfill des enregistrements privés existants vers `user_factor_overlays`
- Fix RPC (ambiguïté workspace_id) dans migration additionnelle
- Edge Function `import-csv-user` adaptée (upsert overlays, refresh par source, trigger RunTask EU)
- Documentation mise à jour (docs/README.md, docs/api/edge-function-api.md)

Objectif
Empêcher qu’un full reindex supra‑admin n’écrase les imports users, tout en gardant un flux utilisateurs 100% côté DB.

Détails techniques
- calculate_factor_key: FE+Date inclus; langue/scope exclus
- staging admin: `run_import_from_staging()` inchangé côté SCD1, mais projection et RunTask EU pointent sur la projection unifiée
- Users: RPC retourne `{ inserted, updated }` pour métriques; projection rafraîchie par `dataset_name`

Migrations
- 20250910_user_overlays_and_unified_projection.sql
- 20250910_unify_projection_with_overlays.sql
- 20250910_backfill_users_to_overlays.sql
- 20250910_fix_batch_upsert_user_overlays.sql

Test rapide
- RPC: `select public.batch_upsert_user_factor_overlays('<ws_uuid>', 'Dataset_Test_Overlay', jsonb_build_array(jsonb_build_object('Nom','Test','FE','1','Unité donnée d\'activité','kgCO2e/un','Source','Dataset_Test_Overlay','Périmètre','WTT','Localisation','FR','Date','2024')));`
- Edge: `import-csv-user` avec petit CSV -> check `data_imports`, `user_factor_overlays`, `emission_factors_all_search` filtré par Source

Sécurité & perfs
- RPC en SECURITY DEFINER; extensions `pgcrypto`/`pg_net`
- Aucun rebuild global nécessaire ; refresh par source uniquement

Merci pour la revue 🙏